### PR TITLE
Changed config files to require a ".conf" file ending

### DIFF
--- a/kvm-simple-init
+++ b/kvm-simple-init
@@ -99,7 +99,7 @@ send_qemu_cmd() {
 # Load environment variables in the configuration file
 load_vm_config() {
 	vmname="$1"
-	vmfile="$CONFDIR/$vmname"
+	vmfile="$CONFDIR/${vmname}.conf"
 
 	if ! [ -r "$vmfile" ]; then
 		echo "$vmfile not readable. Aborting."
@@ -174,7 +174,7 @@ vm_stop() {
 ###############################################################################
 
 if [ $# -eq 1 ]; then
-	vmnames=$(ls $CONFDIR)
+	vmnames=$(ls ${CONFDIR}/*.conf | xargs -n1 basename)
 elif [ $# -eq 2 ]; then
 	vmnames=$2
 else
@@ -185,6 +185,8 @@ action="$1"
 retcode=0
 
 for vmname in $vmnames; do
+	vmname=${vmname%.conf}
+	
 	if [ "$action" = "start" ]; then
 		vm_start $vmname || retcode=1
 	elif [ "$action" = "stop" ]; then


### PR DESCRIPTION
I did this so I can include a common file that is within the config directory without creating a new folder or causing the script to try to start a VM for the file.
